### PR TITLE
iOS 11 Changes

### DIFF
--- a/Falcon/FormDataSource.swift
+++ b/Falcon/FormDataSource.swift
@@ -47,8 +47,13 @@ public class FormDataSource: NSObject {
                 tableView?.register(type.nib, forCellReuseIdentifier: type.reuseIdentifier)
             }
             
-            tableView?.register(section.headerViewType, forHeaderFooterViewReuseIdentifier: String(describing: section.headerViewType))
-            tableView?.register(section.footerViewType, forHeaderFooterViewReuseIdentifier: String(describing: section.footerViewType))
+            if let sectionHeaderViewType = section.headerViewType {
+                tableView?.register(sectionHeaderViewType, forHeaderFooterViewReuseIdentifier: String(describing: sectionHeaderViewType))
+            }
+            
+            if let sectionFooterViewType = section.footerViewType {
+                tableView?.register(sectionFooterViewType, forHeaderFooterViewReuseIdentifier: String(describing: sectionFooterViewType))
+            }
         }
     }
     
@@ -156,8 +161,8 @@ extension FormDataSource: UITableViewDataSource {
             return UITableViewAutomaticDimension
         }
         
-        guard formSections[section].header != nil else {
-            return UITableViewAutomaticDimension
+        guard formSections[section].headerViewType != nil else {
+            return 0
         }
 
         return CGFloat(formSections[section].headerHeight)
@@ -168,20 +173,22 @@ extension FormDataSource: UITableViewDataSource {
             return UITableViewAutomaticDimension
         }
         
-        guard formSections[section].footer != nil  else {
-            return UITableViewAutomaticDimension
+        guard formSections[section].footerViewType != nil  else {
+            return 0
         }
 
         return CGFloat(formSections[section].footerHeight)
     }
     
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard tableView.style == .plain else {
+        
+        guard tableView.style == .plain  else {
             return nil
         }
         
-        let type = formSections[section].headerViewType
-        
+        guard let type = formSections[section].headerViewType else {
+            return nil
+        }
         guard let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: String(describing: type)) else {
             return nil
         }
@@ -198,7 +205,9 @@ extension FormDataSource: UITableViewDataSource {
             return nil
         }
         
-        let type = formSections[section].footerViewType
+        guard let type = formSections[section].footerViewType else {
+            return nil
+        }
         
         guard let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: String(describing: type)) else {
             return nil

--- a/Falcon/FormSection.swift
+++ b/Falcon/FormSection.swift
@@ -9,20 +9,39 @@
 import Foundation
 
 public class FormSection {
-    public var header: String?
-    public var footer: String?
+    public var header: String? {
+        didSet {
+            guard headerViewType == nil else { return }
+            if header == nil {
+                headerViewType = nil
+            } else {
+                headerViewType = PlainSectionView.self
+            }
+        }
+    }
+    public var footer: String? {
+        didSet {
+            guard footerViewType == nil else { return }
+            if footer == nil {
+                footerViewType = nil
+            } else {
+                footerViewType = PlainSectionView.self
+            }
+        }
+    }
+    
     public var rows: [FormRowType] = []
     
     public typealias SectionViewConfigBlock = (UITableViewHeaderFooterView) -> ()
     
-    fileprivate(set) var headerViewType: UITableViewHeaderFooterView.Type = PlainSectionView.self
+    fileprivate(set) var headerViewType: UITableViewHeaderFooterView.Type? = nil
     fileprivate(set) var headerConfigBlock: SectionViewConfigBlock? = { (view) in
         let plainSectionView = view as! PlainSectionView
         plainSectionView.isUppercase = true
     }
     public var headerHeight = 28
     
-    fileprivate(set) var footerViewType: UITableViewHeaderFooterView.Type = PlainSectionView.self
+    fileprivate(set) var footerViewType: UITableViewHeaderFooterView.Type? = nil
     fileprivate(set) var footerConfigBlock: SectionViewConfigBlock?
     public var footerHeight = 28
     
@@ -38,7 +57,13 @@ public class FormSection {
     
     public init(header: String? = nil, footer: String? = nil, rows: [FormRowType]? = []) {
         self.header = header
+        if header != nil {
+            self.headerViewType = PlainSectionView.self
+        }
         self.footer = footer
+        if footer != nil {
+            self.footerViewType = PlainSectionView.self
+        }
         if let rows = rows {
             self.rows = rows
         }


### PR DESCRIPTION
Some behavioral differences in iOS 11 
tableView(_:viewForHeaderInSection:) is now called all the time in iOS 10 it was not

On iOS 11 specifying size as UITableViewAutomaticDimension even though viewForHeader in section is nil and titleForHeaderInSection is nil results in a a header view being shown 

Xcode 9 required